### PR TITLE
Overflow Policy

### DIFF
--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -208,13 +208,8 @@ inline bool GenericThreadPool<Task, Queue>::tryPostImpl(Handler&& handler, size_
             // processing the items in its queue. We then re-try posting our current task.
             if (success)
                 return true;
-            else
-            {
-                if (failedWakeupRetryCap == 0)
-                    return false;
-                
+            else if (failedWakeupRetryCap > 0)
                 return tryPostImpl(std::forward<Handler>(handler), failedWakeupRetryCap - 1);
-            }
         }
     }
 

--- a/include/thread_pool/worker.hpp
+++ b/include/thread_pool/worker.hpp
@@ -43,7 +43,7 @@ class Worker final
     /**
     * @brief State An Enum representing the Rouser thread state.
     */
-    enum State
+    enum class State
     {
         Initialized,
         Running,
@@ -100,6 +100,8 @@ public:
     /**
     * @brief stop Stop all worker's thread and stealing activity.
     * Waits until the executing thread becomes finished.
+    * @note Stop may only be called once start() has been invoked. 
+    * Repeated successful calls to stop() will be no-ops after the first.
     */
     void stop();
 
@@ -245,6 +247,8 @@ inline void Worker<Task, Queue>::stop()
         wake();
         m_thread.join();
     }
+    else if (expectedState == State::Initialized)
+        throw std::runtime_error("Cannot stop Worker: stop may only be calld after the Worker has been started.");
 }
 
 template <typename Task, template<typename> class Queue>


### PR DESCRIPTION
Added thread pool queue overflow policy - upon worker queue posting failure, we retry posting once to each worker in the pool. Only once we fail to fill any queue (in one pass), we consider the post to have failed overall.

Also included two bugfixes, and we now use one state variable instead of atomic booleans in the rouser and workers.