### PR TITLE
fix: gcc-11 build issues/warnings in thread-pool-cpp

### DIFF
--- a/include/thread_pool/thread_pool_options.hpp
+++ b/include/thread_pool/thread_pool_options.hpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <functional>
 #include <chrono>
+#include <cmath>
 
 namespace tp
 {
@@ -203,7 +204,7 @@ inline size_t ThreadPoolOptions::BusyWaitOptions::defaultNumIterations()
 
 inline ThreadPoolOptions::BusyWaitOptions::IterationFunction ThreadPoolOptions::BusyWaitOptions::defaultIterationFunction()
 {
-    return [](size_t i) { return std::chrono::microseconds(static_cast<size_t>(pow(2, i))*1000); };
+    return [](size_t i) { return std::chrono::microseconds(static_cast<size_t>(std::pow(2, i))*1000); };
 }
 
 inline ThreadPoolOptions::ThreadPoolOptions(size_t thread_count, size_t queue_size, size_t failed_wakeup_retry_cap, BusyWaitOptions busy_wait_options, std::chrono::microseconds rouse_period)

--- a/include/thread_pool/worker.hpp
+++ b/include/thread_pool/worker.hpp
@@ -389,7 +389,7 @@ inline void Worker<Task, Queue>::threadFunc(const size_t id, std::shared_ptr<Thr
             }
         }
     }
-    catch (WorkerStoppedException)
+    catch (WorkerStoppedException const&)
     {
         // Allow thread function to complete.
     }

--- a/tests/fixed_function.t.cpp
+++ b/tests/fixed_function.t.cpp
@@ -115,11 +115,11 @@ TEST(FixedFunction, allocDealloc)
     }
 
     ASSERT_EQ(def + cop + mov, destroyed);
-    ASSERT_EQ(2, def);
-    ASSERT_EQ(0, cop);
-    ASSERT_EQ(6, mov);
-    ASSERT_EQ(0, cop_ass);
-    ASSERT_EQ(0, mov_ass);
+    ASSERT_EQ(2u, def);
+    ASSERT_EQ(0u, cop);
+    ASSERT_EQ(6u, mov);
+    ASSERT_EQ(0u, cop_ass);
+    ASSERT_EQ(0u, mov_ass);
 }
 
 TEST(FixedFunction, freeFunc)

--- a/tests/thread_pool.t.cpp
+++ b/tests/thread_pool.t.cpp
@@ -10,7 +10,7 @@
 namespace TestLinkage {
 size_t getWorkerIdForCurrentThread()
 {
-    return *tp::detail::thread_id();
+    return tp::detail::thread_id();
 }
 
 size_t getWorkerIdForCurrentThread2()

--- a/tests/thread_pool_options.t.cpp
+++ b/tests/thread_pool_options.t.cpp
@@ -8,7 +8,7 @@ TEST(ThreadPoolOptions, ctor)
 {
     tp::ThreadPoolOptions options;
 
-    ASSERT_EQ(1024, options.queueSize());
+    ASSERT_EQ(1024u, options.queueSize());
     ASSERT_EQ(std::max<size_t>(1u, std::thread::hardware_concurrency()),
               options.threadCount());
 }
@@ -18,10 +18,10 @@ TEST(ThreadPoolOptions, modification)
     tp::ThreadPoolOptions options;
 
     options.setThreadCount(5);
-    ASSERT_EQ(5, options.threadCount());
+    ASSERT_EQ(5u, options.threadCount());
 
     options.setQueueSize(32);
-    ASSERT_EQ(32, options.queueSize());
+    ASSERT_EQ(32u, options.queueSize());
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fixes some build issues/warnings encountered under gcc-11.
Also updates googletest submodule to release tag 1.11.0 (also to resolve gcc-11 build warnings)